### PR TITLE
Switch from PHP 5.5 to PHP 5.6

### DIFF
--- a/puppet/precip/manifests/php.pp
+++ b/puppet/precip/manifests/php.pp
@@ -1,5 +1,14 @@
 class precip::php {
   
+  ::apt::key { '14AA40EC0831756756D7F66C4F4EA0AAE5267A6C':
+    server => 'hkp://keyserver.ubuntu.com:80'
+  }
+  
+  ::apt::ppa { 'ppa:ondrej/php5-5.6':
+    package_manage => true,
+    require => ::Apt::Key['14AA40EC0831756756D7F66C4F4EA0AAE5267A6C']
+  }
+  
   class { 'php::cli': }
   
   file {[
@@ -50,7 +59,7 @@ class precip::php {
       'xdebug.remote_connect_back' => '1',
       'xdebug.idekey' => 'vagrant',
     },
-    zend => '/usr/lib/php5/20121212',
+    zend => '/usr/lib/php5/20131226',
     notify => Service['httpd'],
   }
   

--- a/puppet/precip/manifests/php.pp
+++ b/puppet/precip/manifests/php.pp
@@ -48,7 +48,6 @@ class precip::php {
     'curl',
     'xdebug',
     'imagick',
-    'xhprof',
     'memcached']:
     notify => Service['httpd'],
   }


### PR DESCRIPTION
Using PHP 5.6 was blocked by a known-issue with Acquia Cloud where NewRelic wasn't working if you were using 5.6. We love NewRelic, so we stuck with 5.5.

This issue has since been resolved, so we should be looking at what it'd take to upgrade Precip to use 5.6, likely through Ondřej's great PPA where he maintains PHP 5.6 stuff.

So far I've got the PPA added, but not everything is working yet:
- How will we run all `apt::ppa`'s before installing anything via apt, or at least before installing any PHP stuff. Maybe by chaining the calls to `php::cli` and `php::module`?
- Why was installing Percona failing during provision? Possibly because of related PPA problems?
- How will we support migrating from 5.5 -> 5.6? Just pulling and running provision won't be enough as it stands right now. It'll add the PPA, but won't upgrade PHP and related packages. Some way to trigger `apt-get upgrade php5` if the existing PHP version is < 5.6?
