### PR TITLE
Refactor first-boot detection

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,13 @@ require "json"
 drupal_sites = ""
 drupal_basepath = "sites"
 
+# Determine if this is our first boot or not. 
+# If there's a better way to figure this out we now have a single place to change.
+first_boot = true
+if File.file?('.vagrant/machines/default/virtualbox/action_provision')
+  first_boot = false
+end
+
 ext_config = File.read 'config.rb'
 eval ext_config
 
@@ -56,8 +63,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder drupal_basepath, "/nfs-www", type: "nfs"
     config.bindfs.bind_folder "/nfs-www", "/srv/www", user: "www-data", group: "www-data"
     
-    # Determine if we've provisioned yet...
-    if !File.file?('.vagrant/machines/default/virtualbox/action_provision')
+    if first_boot
       # MySQL has to be mounted with vboxsf initially, because MySQL Is Terrible
       config.vm.synced_folder "mysql", "/var/lib/mysql", owner: "mysql", group: "mysql"
     else 
@@ -89,6 +95,7 @@ Vagrant.configure(2) do |config|
       "drupal_sites_path" => Dir.pwd + "/" + drupal_basepath,
       "drupal_siteinfo" => drupal_sites.to_json,
       "drupal_hosts" => drupal_sites.collect { |k,v| v["host"] }.concat(drupal_sites.collect { |k,v| v["aliases"] }.flatten.select! { |x| !x.nil? }).to_json,
+      "first_boot" => first_boot,
     }
   end
 end

--- a/puppet/precip/manifests/database.pp
+++ b/puppet/precip/manifests/database.pp
@@ -64,11 +64,13 @@ class precip::database {
     require    => Mysql_user['root@%'],
   }
   
-  # For some reason, MySQL isn't *really* available to all hosts until 
-  # you restart it. So we need to restart it.
-  exec { "restart-mysqld-after-grant":
-    path => ["/bin", "/sbin", "/usr/bin", "/usr/sbin/"],
-    command => "service mysql restart",
-    require => Mysql_grant["root@%/*.*"],
+  # MySQL isn't *really* available to all hosts until you restart it. 
+  # So we need to restart it on *first boot only*.
+  if str2bool("$first_boot") {
+    exec { "restart-mysqld-after-grant":
+      path => ["/bin", "/sbin", "/usr/bin", "/usr/sbin/"],
+      command => "service mysql restart",
+      require => Mysql_grant["root@%/*.*"],
+    }
   }
 }

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -64,8 +64,10 @@ class precip {
   }
 
   # Install statically-compiled versions of wkhtmltopdf / wkhtmltoimage
-  class { 'wkhtmltox':
-    ensure => present,
+  if str2bool("$first_boot") {
+    class { 'wkhtmltox':
+      ensure => present,
+    }
   }
 
   # Add all our hosts to /etc/hosts


### PR DESCRIPTION
We have a few bits of the provisioning process that only need to run once, but don’t behave properly and instead run every time you provision Just Because.

We had first-boot detection in the Vagrantfile that was being used to ensure MySQL’s data directory was mounted as vboxsf first then bind+nfs later. I took that method, extrapolated it into a variable in the Vagrantfile, and then passed that variable into facter.

With the fact in place, I was then able to wrap wkhtmltox and that one-time mysql restart in a test for that fact, so now it doesn’t re-run on boot.

To test:
- pull branch
- `vagrant destroy -f && vagrant up`
- check to see that wkhtmltox is installed, and that you can connect to mysql via SequelPro (or whatever)
- `vagrant reload —provision`
- check to see that it didn’t blindly restart mysql and re-install wkhtmltox

The only things that should now run when you reprovision are:
`==> default: Notice: /Stage[main]/Precip::Database/File[/etc/mysql/debian.cnf]/mode: mode changed '0600' to '0644'`
(which we could probably change), and anything else that’s actually _new_.
