### PR TITLE
Implement Mailhog

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2015 Clearwater Development
+Copyright (c) 2015-2016 Clearwater Development
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full LAMP stack, and a few nice extras.
 - Percona Server 5.5
 - PHP 5.6
   - With Memcache, OPCache, and Xdebug all pre-configured
-- MailCatcher, the simplest way to locally test mail delivery
+- MailHog, the _absolute_ simplest way to locally test mail delivery
 
 ## Why not build your own box from scratch?
 **Precip** offers a few key benefits over rolling your own completely custom Vagrant setup that may not be _immediately_ apparent from staring at a freshly `vagrant init`'ed box.
@@ -84,10 +84,10 @@ Want Apache Logs? Don't want to SSH into the VM and sudo to root and other terri
 
 The [XHProf PHP Extension](http://php.net/manual/en/book.xhprof.php) is also built in. There's a [pretty nice Drupal Module](https://www.drupal.org/project/xhprof) that can hook into it.
 
-## MailCatcher
-[MailCatcher](http://mailcatcher.me) is a magic Ruby app that acts as an alternative mailhandler. Instead of actually sending mail, it just collects it and makes it available to you in a nice local web UI. Said web UI lives on port 1080: [precip.vm:1080](http://precip.vm:1080).
+## MailHog
+[MailHog](https://github.com/mailhog/MailHog) is an alternative mailhandler written in Go. Similar to MailCatcher it collects mail sent by PHP (or, anything actually) and puts it in a friendly local web UI. Said web UI lives on port 8025: [precip.vm:8025](http://precip.vm:8025). The major benefit MailHog has over MailCatcher is that it's written in Go and is distributed as a statically-compiled binary, so we don't have a mile-long list of Ruby dependencies to reconcile before installing.
 
-PHP is already set up to use it, but if for some reason you're making something that needs to directly talk to it, tell it there is *totally* an SMTP server at `smtp://localhost:1025`, and MailCatcher should take it from there.
+PHP is already set up to use it, but if for some reason you're making something that needs to directly talk to it, tell it there is *totally* an SMTP server at `smtp://localhost:1025`, and MailHog should take it from there.
 
 ## Adding additional repos - quick reference
 - Clone your repo to a new directory under `/sites`
@@ -116,4 +116,4 @@ PHP is already set up to use it, but if for some reason you're making something 
 - [ ] Other Cool Stuff
 
 # Legal
-**Precip** is in no way associated with Acquia Inc or Drupal. Drupal is a registered trademark of Dries Buytaert. **Precip** is available under the MIT License. Want to hack on it? Send a Pull Request. Find a bug? File an issue. (or a Pull Request) (preferably a Pull Request)
+**Precip** is in no way associated with Acquia, Inc. or Drupal. Drupal is a registered trademark of Dries Buytaert. **Precip** is available under the MIT License. Want to hack on it? Send a Pull Request. Find a bug? File an issue. (or a Pull Request) (preferably a Pull Request)

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -7,9 +7,10 @@ mod 'puppetlabs-apache'
 mod 'puppetlabs-apt'
 mod 'puppetlabs-mysql', "3.2.0"
 
-mod 'thias-php'
+mod 'thias-php', "1.1.1"
 
-mod 'actionjack-mailcatcher'
+mod 'thbe-ssmtp'
+mod 'ftaeger-mailhog'
 
 mod 'willdurand-composer'
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,30 +1,29 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    actionjack-mailcatcher (0.1.11)
-      puppetlabs-ruby (>= 0.3.0)
-      puppetlabs-stdlib (>= 4.2.0)
+    ftaeger-mailhog (1.0.8)
+      maestrodev-wget (< 2.0.0, >= 1.7.3)
+      puppetlabs-stdlib (< 5.0.0, >= 4.10.0)
     jlondon-wkhtmltox (1.0.11)
       maestrodev-wget (>= 1.5.0)
       puppetlabs-stdlib (>= 0)
-    maestrodev-wget (1.7.1)
+    maestrodev-wget (1.7.3)
     nanliu-staging (1.0.3)
-    puppetlabs-apache (1.4.0)
-      puppetlabs-concat (< 2.0.0, >= 1.1.1)
+    puppetlabs-apache (1.9.0)
+      puppetlabs-concat (< 3.0.0, >= 1.1.1)
       puppetlabs-stdlib (< 5.0.0, >= 2.4.0)
-    puppetlabs-apt (2.2.1)
-      puppetlabs-stdlib (>= 4.5.0)
-    puppetlabs-concat (1.2.5)
+    puppetlabs-apt (2.2.2)
+      puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
+    puppetlabs-concat (2.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-mysql (3.2.0)
       nanliu-staging (~> 1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-ruby (0.4.0)
-      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-stdlib (4.11.0)
+    puppetlabs-stdlib (4.12.0)
+    thbe-ssmtp (0.5.8)
     thias-php (1.1.1)
-    willdurand-composer (1.1.1)
-      maestrodev-wget (>= 1.2.0)
+    willdurand-composer (1.2.1)
+      puppetlabs-stdlib (>= 3.2.1)
 
 PATH
   remote: /vagrant/puppet/precip
@@ -32,11 +31,13 @@ PATH
     clwdev-precip (0.0.1)
 
 DEPENDENCIES
-  actionjack-mailcatcher (>= 0)
   clwdev-precip (>= 0)
+  ftaeger-mailhog (>= 0)
   jlondon-wkhtmltox (>= 0)
   puppetlabs-apache (>= 0)
   puppetlabs-apt (>= 0)
   puppetlabs-mysql (= 3.2.0)
+  thbe-ssmtp (>= 0)
   thias-php (>= 0)
   willdurand-composer (>= 0)
+

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -58,10 +58,6 @@ class precip {
     target => "/usr/share/zoneinfo/US/Eastern",
   }
 
-  # Bring in Mailcatcher, because Mailcatcher is neat.
-  # class { 'mailcatcher': 
-  #   require => Package['g++']
-  # }
 
   # Install statically-compiled versions of wkhtmltopdf / wkhtmltoimage
   if str2bool("$first_boot") {

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -58,11 +58,19 @@ class precip {
     target => "/usr/share/zoneinfo/US/Eastern",
   }
 
-
-  # Install statically-compiled versions of wkhtmltopdf / wkhtmltoimage
   if str2bool("$first_boot") {
+    # Install statically-compiled versions of wkhtmltopdf / wkhtmltoimage
     class { 'wkhtmltox':
       ensure => present,
+    }
+
+    # Install MailHog & ssmtp, an alternative to Mailcatcher
+    class { '::ssmtp':
+      mail_hub => 'localhost:1025',
+    }
+
+    class { 'mailhog':
+      api_bind_host => 'precip.vm',
     }
   }
 

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -66,11 +66,23 @@ class precip {
 
     # Install MailHog & ssmtp, an alternative to Mailcatcher
     class { '::ssmtp':
-      mail_hub => 'localhost:1025',
+      mail_hub => '127.0.0.1:1025',
     }
 
     class { 'mailhog':
       api_bind_host => 'precip.vm',
+    }
+    
+    check_mode { '/etc/ssmtp/ssmtp.conf':
+      mode => 644,
+      require => File['/etc/ssmtp/ssmtp.conf'],
+    }
+  }
+
+  # Awful hack to fix the permissions on ssmtp's config file
+  define check_mode($mode) {
+    exec { "/bin/chmod $mode $name":
+      unless => "/bin/sh -c '[ $(/usr/bin/stat -c %a $name) == $mode ]'",
     }
   }
 

--- a/puppet/precip/manifests/php.pp
+++ b/puppet/precip/manifests/php.pp
@@ -38,7 +38,7 @@ class precip::php {
     display_errors => 'On',
     html_errors => 'On',
     session_save_path => '/tmp',
-    sendmail_path => '/usr/bin/env catchmail',
+    sendmail_path => '/usr/sbin/ssmtp -t',
     notify => Service['httpd'],
     require => File['/etc/php5/apache2']
   }

--- a/puppet/precip/templates/restart_services_once_mounted.conf.erb
+++ b/puppet/precip/templates/restart_services_once_mounted.conf.erb
@@ -4,5 +4,4 @@ start on vagrant-mounted
 script
   sudo service apache2 restart
   sudo service mysql restart
-  sudo service mailcatcher restart
 end script

--- a/util/mail_test.php
+++ b/util/mail_test.php
@@ -1,6 +1,6 @@
 <?php
 $to      = 'fake@fake.fake';
-$subject = 'mailcatcher test';
+$subject = 'mail test';
 $message = 'hello world!';
 $headers = 'From: webmaster@example.com' . "\r\n" .
     'Reply-To: webmaster@example.com' . "\r\n" .
@@ -9,4 +9,4 @@ $headers = 'From: webmaster@example.com' . "\r\n" .
 mail($to, $subject, $message, $headers);
 ?>
 
-Mail sent! Go check <a href="http://<?php echo $_SERVER['HTTP_HOST']; ?>:1080">MailCatcher</a>!
+Mail sent! Go check <a href="http://<?php echo $_SERVER['HTTP_HOST']; ?>:8025">MailHog</a>!


### PR DESCRIPTION
Resolves issue #20.

Luckily it turns out there _are_ some Puppet Modules now that install MailHog and sSMTP, so I’ve used them here. _Way_ better than having to write my own.
