### PR TITLE
Refactor how we get MailHog

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -9,9 +9,6 @@ mod 'puppetlabs-mysql', "3.2.0"
 
 mod 'thias-php', "1.1.1"
 
-mod 'thbe-ssmtp'
-mod 'ftaeger-mailhog'
-
 mod 'willdurand-composer'
 
 mod 'jlondon-wkhtmltox'

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,9 +1,6 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    ftaeger-mailhog (1.0.8)
-      maestrodev-wget (< 2.0.0, >= 1.7.3)
-      puppetlabs-stdlib (< 5.0.0, >= 4.10.0)
     jlondon-wkhtmltox (1.0.11)
       maestrodev-wget (>= 1.5.0)
       puppetlabs-stdlib (>= 0)
@@ -24,7 +21,6 @@ FORGE
     saz-memcached (2.8.1)
       puppetlabs-firewall (>= 0.1.0)
       puppetlabs-stdlib (>= 3.2.0)
-    thbe-ssmtp (0.5.8)
     thias-php (1.1.1)
     willdurand-composer (1.2.1)
       puppetlabs-stdlib (>= 3.2.1)
@@ -36,13 +32,11 @@ PATH
 
 DEPENDENCIES
   clwdev-precip (>= 0)
-  ftaeger-mailhog (>= 0)
   jlondon-wkhtmltox (>= 0)
   puppetlabs-apache (>= 0)
   puppetlabs-apt (>= 0)
   puppetlabs-mysql (= 3.2.0)
   saz-memcached (>= 0)
-  thbe-ssmtp (>= 0)
   thias-php (= 1.1.1)
   willdurand-composer (>= 0)
 

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -63,20 +63,6 @@ class precip {
     class { 'wkhtmltox':
       ensure => present,
     }
-
-    # Install MailHog & ssmtp, an alternative to Mailcatcher
-    class { '::ssmtp':
-      mail_hub => '127.0.0.1:1025',
-    }
-
-    class { 'mailhog':
-      api_bind_host => 'precip.vm',
-    }
-    
-    check_mode { '/etc/ssmtp/ssmtp.conf':
-      mode => 644,
-      require => File['/etc/ssmtp/ssmtp.conf'],
-    }
   }
 
   # Awful hack to fix the permissions on ssmtp's config file

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -82,6 +82,7 @@ class precip {
   class { 'memcached': }
 
   # Kick off the rest of our manifests
+  include 'precip::mailhog'
   include 'precip::php'
   include 'precip::httpd'
   include 'precip::database'

--- a/puppet/precip/manifests/mailhog.pp
+++ b/puppet/precip/manifests/mailhog.pp
@@ -1,0 +1,69 @@
+# Adapted from Chassis/MailHog
+class precip::mailhog ( 
+  $install_path = '/usr/local/bin/mailhog', 
+  $mailhog_version = '0.2.1',
+  $mhsendmail_version = '0.2.0',
+  ) {
+
+	file { $install_path:
+		ensure => directory,
+	}
+
+  # Download & Link Mailhog
+	exec { "mailhog download $mailhog_version":
+		command => "/usr/bin/curl -o $install_path/mailhog-$mailhog_version -L https://github.com/mailhog/MailHog/releases/download/v$mailhog_version/MailHog_linux_amd64",
+		require => [ Package['curl'], File[ "$install_path" ] ],
+		creates => "$install_path/mailhog-$mailhog_version",
+	}
+
+	file { "$install_path/mailhog-$mailhog_version":
+		ensure => present,
+		mode => "a+x",
+		require => Exec["mailhog download $mailhog_version"],
+    notify => File['/usr/bin/mailhog'],
+	}
+
+	file { '/usr/bin/mailhog':
+		ensure => link,
+		target => "$install_path/mailhog-$mailhog_version",
+		require => File[ "$install_path/mailhog-$mailhog_version" ],
+	}
+
+  # Download & Link mhsendmail
+  exec { "mhsendmail download $mhsendmail_version":
+		command => "/usr/bin/curl -o $install_path/mhsendmail-$mhsendmail_version -L https://github.com/mailhog/mhsendmail/releases/download/v$mhsendmail_version/mhsendmail_linux_amd64",
+		require => [ Package['curl'], File[ "$install_path" ] ],
+		creates => "$install_path/mhsendmail-$mhsendmail_version",
+	}
+
+  file { "$install_path/mhsendmail-$mhsendmail_version":
+		ensure => present,
+		mode => "a+x",
+		require => Exec["mhsendmail download $mhsendmail_version"],
+    notify => File['/usr/bin/mhsendmail'],
+	}
+
+	file { '/usr/bin/mhsendmail':
+		ensure => link,
+		target => "$install_path/mhsendmail-$mhsendmail_version",
+		require => File[ "$install_path/mhsendmail-$mhsendmail_version" ],
+	}
+
+	file { '/etc/init/mailhog.conf':
+		content => template('precip/mailhog_upstart.conf.erb'),
+	}
+
+	service { 'mailhog':
+    enable => true,
+    ensure => running,
+    hasrestart => true,
+    hasstatus => true,
+    require => [ File['/etc/init/mailhog.conf'], File['/usr/bin/mailhog'] ]
+	}
+
+	if ! defined(Package['curl']) {
+		package { 'curl':
+			ensure => installed,
+		}
+	}
+}

--- a/puppet/precip/manifests/php.pp
+++ b/puppet/precip/manifests/php.pp
@@ -38,7 +38,7 @@ class precip::php {
     display_errors => 'On',
     html_errors => 'On',
     session_save_path => '/tmp',
-    sendmail_path => '/usr/sbin/ssmtp -t',
+    sendmail_path => '/usr/bin/mhsendmail',
     notify => Service['httpd'],
     require => File['/etc/php5/apache2']
   }

--- a/puppet/precip/templates/mailhog_upstart.conf.erb
+++ b/puppet/precip/templates/mailhog_upstart.conf.erb
@@ -1,0 +1,16 @@
+description "Mailhog"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+
+pre-start script
+
+bash << "EOF"
+  mkdir -p /var/log/mailhog
+  chown -R vagrant /var/log/mailhog
+EOF
+
+end script
+
+exec su - vagrant -c '/usr/bin/mailhog -api-host=precip.vm &>>/var/log/mailhog/mailhog.log'


### PR DESCRIPTION
Drops our dependency on the now defunct ftaeger/ftaeger-mailhog puppet module. Resolves #24.
