### PR TITLE
Switch MySQL from nfs+bindfs to an external persistent .vdi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/*
 puppet/modules/*
 *.aliases.drushrc.php
 precip.box
+*.vdi

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A full LAMP stack, and a few nice extras.
   - `$ vagrant plugin install vagrant-hostsupdater`
   - `$ vagrant plugin install vagrant-useradd`
   - `$ vagrant plugin install vagrant-bindfs`
+  - `$ vagrant plugin install vagrant-vagrant-persistent-storage`
 
 ## Git Clones & Configuration
 - Clone this repo
@@ -99,7 +100,6 @@ PHP is already set up to use it, but if for some reason you're making something 
 
 # Known Issues
 - [ ] During Provisioning, Puppet complains about "Warning: Setting templatedir is deprecated." [It's a Vagrant Bug](https://github.com/mitchellh/vagrant/issues/3740).
-- [ ] Provisioning MySQL is *super* weird, and will perma-bomb if you kill the box between first-boot and MySQL being installed. (Pro-tip: Don't do that.) (But if you do, just `$ vagrant destroy -f && vagrant up`)
 
 # @TODO
 - [x] ~~Puppet Library Caching~~
@@ -110,8 +110,8 @@ PHP is already set up to use it, but if for some reason you're making something 
 - [x] ~~Super Secret Automagical repo detection and cloning from config.rb~~
 - [x] ~~phpMyAdmin support~~
 - [x] ~~Actual Testing on Windows~~
-- [ ] Figure out NFS support on Windows
-- [ ] [Pimp My Log](http://pimpmylog.com) support
+- [ ] ~~Figure out NFS support on Windows~~ (gave up)
+- [ ] [Pimp My Log](http://pimpmylog.com) support (In progress, see PR #26)
 - [ ] Some sort of generalized environment pulldown script
 - [ ] Other Cool Stuff
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,7 @@ Vagrant.configure(2) do |config|
   config.persistent_storage.mountpoint = '/var/lib/mysql'
   
   # Want to mount your *old* MySQL dir so you can copy your old files over? 
-  # Uncomment this, vagrat reload, and run: vagrant ssh -c "sudo bash /vagrant/shell/migrate-db.sh"
+  # Uncomment this and run: vagrant reload && vagrant ssh -c "sudo bash /vagrant/shell/migrate-db.sh"
   #config.vm.synced_folder "mysql", "/var/lib/mysql-old", owner: "mysql", group: "mysql"
   
   # Mount the gitignored puppet/modules directory, for caching

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,6 +72,10 @@ Vagrant.configure(2) do |config|
   config.persistent_storage.filesystem = 'ext4'
   config.persistent_storage.mountpoint = '/var/lib/mysql'
   
+  # Want to mount your *old* MySQL dir so you can copy your old files over? 
+  # Uncomment this, vagrat reload, and run: vagrant ssh -c "sudo bash /vagrant/shell/migrate-db.sh"
+  #config.vm.synced_folder "mysql", "/var/lib/mysql-old", owner: "mysql", group: "mysql"
+  
   # Mount the gitignored puppet/modules directory, for caching
   config.vm.synced_folder "puppet/modules", "/etc/puppet/modules"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 %x(vagrant plugin install vagrant-hostsupdater) unless Vagrant.has_plugin?('vagrant-hostsupdater')
 %x(vagrant plugin install vagrant-useradd) unless Vagrant.has_plugin?('vagrant-useradd')
 %x(vagrant plugin install vagrant-bindfs) unless Vagrant.has_plugin?('vagrant-bindfs')
+%x(vagrant plugin install vagrant-persistent-storage) unless Vagrant.has_plugin?('vagrant-persistent-storage')
 
 # Pull in external config
 require "json"
@@ -54,18 +55,22 @@ Vagrant.configure(2) do |config|
 
   # Synced Folders
   if Vagrant::Util::Platform.windows?
-    # Windows gets vboxsf for everything. Sorry Windows!
+    # Windows gets vboxsf, because it can't do nfs + bindfs
     config.vm.synced_folder drupal_basepath, "/srv/www", owner: "www-data", group: "www-data"
-    config.vm.synced_folder "mysql", "/var/lib/mysql", owner: "mysql", group: "mysql"
   else
-    # Everybody else gets nfs + bindfs for their Apache folders
+    # Everybody else gets nfs + bindfs, for better small-file read perf
     config.vm.synced_folder drupal_basepath, "/nfs-www", type: "nfs"
     config.bindfs.bind_folder "/nfs-www", "/srv/www", user: "vagrant", group: "www-data", chown_ignore: true, chgrp_ignore: true, perms: "u=rwx:g=rwx:o=rx"
-    
-    # Once MySQL is installed during initial provisioning we can re-mount with nfs + bindfs
-    config.vm.synced_folder "mysql", "/nfs-sql", type: "nfs"
-    config.bindfs.bind_folder "/nfs-sql", "/var/lib/mysql", user: "mysql", group: "mysql", chown_ignore: true, chgrp_ignore: true
   end
+
+  # MySQL now uses the vagrant-persistent-storage module.
+  # Same concept as before & same benefits, but with the added bonus of being a native filesystem instead of a share.
+  config.persistent_storage.enabled = true
+  config.persistent_storage.location = "mysql.vdi"
+  config.persistent_storage.size = 32768
+  config.persistent_storage.mountname = 'mysql'
+  config.persistent_storage.filesystem = 'ext4'
+  config.persistent_storage.mountpoint = '/var/lib/mysql'
   
   # Mount the gitignored puppet/modules directory, for caching
   config.vm.synced_folder "puppet/modules", "/etc/puppet/modules"

--- a/shell/migrate-db.sh
+++ b/shell/migrate-db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+service mysql stop
+rm -rf /var/lib/mysql/*
+cp -Rp /var/lib/mysql-old/* /var/lib/mysql
+service mysql start


### PR DESCRIPTION
We've known for awhile that MySQL over NFS is terrible, but it was the best perf we could get to accomplish the following two goals:
- Ensure MySQL Table Files survive a destroy / reprovision
- Ensure that MySQL Table Files don't max out the size of the base box

. . . but NFS is really terrible for large file reads, and MySQL is _all about_ large file reads.

Turns out there's a vagrant plugin for that. So in this PR we switch from MySQL being mounted over nfs+bindfs to MySQL being stored in mysql.vdi, managed by vagrant-persistent-storage.

To Test:
- Export any databases from your current install you may want to keep
- Pull this branch
- `vagrant destroy -f && vagrant up`
- Watch it go
- Import any new DBs you need

How it actually _works_ is seamless, I'm just not building a migration path from directory to image because honestly it's a good idea to flush out and rebuild your MySQL storage from time to time, due to how MySQL allocates and manages its storage.

Couple Notes:
- Vagrant _should_ install the plugin "vagrant-persistent-storage" on reload, if it doesn't and it freaks out run `vagrant plugin install vagrant-persistent-storage`. Also tell me so I can work on fixing that.
- This does _not_ delete your old `/mysql` directory. You'll need to clear that out whenever you think you're done with it. Try not to forget it, because it could be a _lot_ of space.
- With this new system we trade better perf for unlimited scaling storage, so the MySQL storage _is_ capped at 32Gb. If it turns out we need _more_ than 32Gb we can tweak it, but for now I'm considering needing 32 gigs of sql storage out of scope. (We _may_ consider changing it to something gigantic like a 256Gb image, because it _does_ auto-scale up, but _only_ up.)
