### PR TITLE
Perf tweaks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,14 +79,13 @@ Vagrant.configure(2) do |config|
   # Mount the gitignored puppet/modules directory, for caching
   config.vm.synced_folder "puppet/modules", "/etc/puppet/modules"
 
-  # Throw more resources at the VM. Tweak as needed
+  # Configure the VM. Tweak as needed
+  configured = -1
   config.vm.provider :virtualbox do |vb|
     # Name this virtual machine "precip"
     vb.customize ["modifyvm", :id, "--name", "precip"]
-    # IOAPIC is needed for a 64bit host
+    # IOAPIC is needed for a 64bit host for multiple cures
     vb.customize ["modifyvm", :id, "--ioapic", "on"]
-    # A single processor still outperforms larger numbers with Virtualbox
-    vb.customize ["modifyvm", :id, "--cpus", "2"]
     # Use ICH9 for performance
     vb.customize ["modifyvm", :id, "--chipset", "ich9"]
     # Deffer DNS resolution to the host for performance
@@ -95,20 +94,37 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--vram", "10"]
     # Prevent a time drift of more than a minute from the host
     vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 60000]
-    # Give this virtual machine 1/4th of the host RAM
+    # Give VM 1/4 system memory (if more than 2GB), otherwise leave as default
+    # Give half of cpu cores as the host (if more than 1), otherwise leave as default
+    # In our testing this produced the best results. Adapted from https://github.com/rdsubhas/vagrant-faster
     host = RbConfig::CONFIG['host_os']
+    cpus = -1
+    mem = -1
     if host =~ /darwin/
-      # sysctl returns Bytes and we need to convert to MB
-      mem = `sysctl -n hw.memsize`.to_i / 1024
+      cpus = `sysctl -n hw.ncpu`.to_i
+      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024
     elsif host =~ /linux/
-      # meminfo shows KB and we need to convert to MB
-      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i 
+      cpus = `nproc`.to_i
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024
     elsif host =~ /mswin|mingw|cygwin/
-      # Windows code via https://github.com/rdsubhas/vagrant-faster
-      mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024
+      cpus = `wmic cpu Get NumberOfCores`.split[1].to_i
+      mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024 / 1024
     end
-    mem = mem / 1024 / 4
-    vb.customize ["modifyvm", :id, "--memory", mem]
+    cpus = cpus / 2 if cpus > 1
+    mem = mem / 4 if mem > 2048
+    if mem > 0
+      vb.customize ["modifyvm", :id, "--memory", mem]
+      if configured < 1
+        puts "Memory set to: #{mem}"
+      end
+    end
+    if cpus > 0
+      vb.customize ["modifyvm", :id, "--cpus", cpus]
+      if configured < 1
+        puts "CPUs set to: #{cpus}"
+      end
+    end
+    configured = 1
   end
 
   # Fix the harmless "stdin: is not a tty" issue once and for all

--- a/shell/package.sh
+++ b/shell/package.sh
@@ -2,19 +2,32 @@
 # Package up this vagrant box for distribution.
 # Usage: sudo bash package.sh
 
+echo "THIS WILL DESTROY AND RECREATE YOUR VAGRANT BOX."
+echo "It is NOT reccomended that you do this using your development environment."
+read -p "Are you sure you still want to do this? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Cancelled."
+  exit
+fi
+
 BASEDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+cd "$BASEDIR/.."
 
 echo "Ensuring a clean machine"
 vagrant destroy --force
 
-cd "$BASEDIR/.."
+echo "Prepping config.rb and sites folder"
 cp config.rb-dist config.rb
+mkdir -p "$BASEDIR/../sites" >/dev/null 2>&1
 
-echo "Installing prerequirements"
+echo "Installing prerequisites"
 vagrant plugin install vagrant-vbguest
 vagrant plugin install vagrant-hostsupdater
 vagrant plugin install vagrant-useradd
 vagrant plugin install vagrant-bindfs
+vagrant plugin install vagrant-persistent-storage
 
 echo "Setting up Vagrant"
 sudo touch /etc/exports
@@ -22,6 +35,7 @@ vagrant up
 vagrant halt
 
 echo "Packaging Vagrant"
+rm -rf precip.box >/dev/null 2>&1
 vagrant package --base precip --output precip.box
 
 echo "Cleaning up"

--- a/shell/setup-osx.sh
+++ b/shell/setup-osx.sh
@@ -71,6 +71,7 @@ vagrant plugin install vagrant-vbguest
 vagrant plugin install vagrant-hostsupdater
 vagrant plugin install vagrant-useradd
 vagrant plugin install vagrant-bindfs
+vagrant plugin install vagrant-persistent-storage
 
 out "Ensuring a clean machine."
 vagrant destroy --force


### PR DESCRIPTION
Gives much higher concurrent performance ~ 40% but will also use less ram on average. This uses 1/2 the cores as the host (if more than 1), and 1/4th the ram (if above 2gb).

Do not merge till after #29 as this is based on that PR.

For this test I disabled all caches, and flushed all of them prior to running apache bench against a complex page with views. My host machine is 64-bit w/ 8 cores.

1 CPU:

```
Benchmarking zeg.vm (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        Apache/2.4.7
Server Hostname:        zeg.vm
Server Port:            80

Document Path:          /brochures
Document Length:        84910 bytes

Concurrency Level:      10
Time taken for tests:   490.312 seconds
Complete requests:      200
Failed requests:        0
Total transferred:      17094600 bytes
HTML transferred:       16982000 bytes
Requests per second:    0.41 [#/sec] (mean)
Time per request:       24515.585 [ms] (mean)
Time per request:       2451.558 [ms] (mean, across all concurrent requests)
Transfer rate:          34.05 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:  5755 24446 43509.7  14546  214111
Waiting:     5710 23865 43332.3  14003  212858
Total:       5756 24447 43509.8  14546  214111

Percentage of the requests served within a certain time (ms)
  50%  14546
  66%  14764
  75%  14888
  80%  14985
  90%  15392
  95%  212840
  98%  214015
  99%  214072
 100%  214111 (longest request)
```

2 CPU:

```
Benchmarking zeg.vm (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        Apache/2.4.7
Server Hostname:        zeg.vm
Server Port:            80

Document Path:          /brochures
Document Length:        84910 bytes

Concurrency Level:      10
Time taken for tests:   351.079 seconds
Complete requests:      200
Failed requests:        0
Total transferred:      17094600 bytes
HTML transferred:       16982000 bytes
Requests per second:    0.57 [#/sec] (mean)
Time per request:       17553.968 [ms] (mean)
Time per request:       1755.397 [ms] (mean, across all concurrent requests)
Transfer rate:          47.55 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:  7304 17492 29828.4  10749  147569
Waiting:     7236 17077 29751.4  10337  146838
Total:       7304 17492 29828.4  10749  147569

Percentage of the requests served within a certain time (ms)
  50%  10749
  66%  10995
  75%  11106
  80%  11284
  90%  11691
  95%  146669
  98%  147323
  99%  147436
 100%  147569 (longest request)
```

4 CPU:

```
Benchmarking zeg.vm (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        Apache/2.4.7
Server Hostname:        zeg.vm
Server Port:            80

Document Path:          /brochures
Document Length:        84910 bytes

Concurrency Level:      10
Time taken for tests:   207.759 seconds
Complete requests:      200
Failed requests:        0
Total transferred:      17094600 bytes
HTML transferred:       16982000 bytes
Requests per second:    0.96 [#/sec] (mean)
Time per request:       10387.948 [ms] (mean)
Time per request:       1038.795 [ms] (mean, across all concurrent requests)
Transfer rate:          80.35 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.3      0       3
Processing:  3996 10321 18117.2   6189   89406
Waiting:     3926 10113 18061.2   5990   88892
Total:       3996 10322 18117.3   6189   89408

Percentage of the requests served within a certain time (ms)
  50%   6189
  66%   6389
  75%   6653
  80%   6790
  90%   7255
  95%  88817
  98%  89092
  99%  89244
 100%  89408 (longest request)
```

8 CPU:

```
Benchmarking zeg.vm (be patient)
Completed 100 requests
Completed 200 requests
Finished 200 requests


Server Software:        Apache/2.4.7
Server Hostname:        zeg.vm
Server Port:            80

Document Path:          /brochures
Document Length:        84910 bytes

Concurrency Level:      10
Time taken for tests:   228.293 seconds
Complete requests:      200
Failed requests:        0
Total transferred:      17094600 bytes
HTML transferred:       16982000 bytes
Requests per second:    0.88 [#/sec] (mean)
Time per request:       11414.647 [ms] (mean)
Time per request:       1141.465 [ms] (mean, across all concurrent requests)
Transfer rate:          73.13 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   2.5      0      16
Processing:  4722 11387 23328.7   5854  112749
Waiting:     4645 11071 22601.3   5711  109270
Total:       4722 11388 23328.7   5854  112750

Percentage of the requests served within a certain time (ms)
  50%   5854
  66%   6120
  75%   6323
  80%   6482
  90%   8356
  95%  112748
  98%  112748
  99%  112749
 100%  112750 (longest request)
```

Based on this it seems the belief that 1 core is faster is a falacy in the context of Virtualbox and Vagrant as it exists today. It was worth a test though to check.
