### PR TITLE
reduce threshold for time sync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,7 @@ Vagrant.configure(2) do |config|
   # Throw more resources at the VM. Tweak as needed
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "2560", "--ioapic", "on", "--cpus", "2", "--chipset", "ich9", "--name", "precip", "--natdnshostresolver1", "on"]
+    vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
   end
 
   # Fix the harmless "stdin: is not a tty" issue once and for all


### PR DESCRIPTION
VirtualBox has a 20 minute threshold for actually syncing time, reducing this will help time based functionality in drupal work better. (e.g. uli)
