### PR TITLE
Restructure to support Puppet 4.x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,11 @@ if File.file?('.vagrant/machines/default/virtualbox/action_provision')
   first_boot = false
 end
 
+# Determine if our config.rb exists or not, fail gracefully
+if !File.file?('config.rb')
+  abort("Error: 'config.rb' is missing. Please review README.md and config.rb-dist to create one.")
+end
+
 ext_config = File.read 'config.rb'
 eval ext_config
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure(2) do |config|
   # This is a happy base box from PuppetLabs
   config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
   # Pin to 1.0.0 for perf reasons
-  config.vm.box_version = "1.0.0"
+  config.vm.box_version = "1.0.3"
 
   # Basic network config.
   config.vm.network :private_network, ip: "10.0.0.11"
@@ -143,8 +143,8 @@ Vagrant.configure(2) do |config|
   
   # Hand off to puppet
   config.vm.provision :puppet, :options => [""] do |puppet|
-    puppet.manifests_path = "puppet/manifests"
-    puppet.manifest_file  = "site.pp"
+    puppet.environment_path = "puppet/environments"
+    puppet.environment = "vm"
     puppet.hiera_config_path = "puppet/hiera.yaml"
   
     # some facts

--- a/config.rb-dist
+++ b/config.rb-dist
@@ -81,8 +81,12 @@
 #
 
 drupal_sites = {
-   "example" => {
-     "host" => "example.vm",
-     "path" => "example/docroot"
-   },
+#   "example" => {
+#     "host" => "example.vm",
+#     "path" => "example/docroot"
+#   },
+}
+
+external_hosts = {
+
 }

--- a/puppet/environments/vm/environment.conf
+++ b/puppet/environments/vm/environment.conf
@@ -1,0 +1,1 @@
+modulepath = /etc/puppet/modules

--- a/puppet/environments/vm/manifests/site.pp
+++ b/puppet/environments/vm/manifests/site.pp
@@ -1,4 +1,4 @@
 # kick it off
 node default {
-  include 'precip'
+  class { 'precip': }
 }

--- a/puppet/precip/manifests/database.pp
+++ b/puppet/precip/manifests/database.pp
@@ -2,7 +2,7 @@ class precip::database {
   file {"/etc/mysql":
     owner => "mysql",
     group => "mysql",
-    mode => 755,
+    mode => '0755',
     ensure => "directory",
   }  
   

--- a/puppet/precip/manifests/php.pp
+++ b/puppet/precip/manifests/php.pp
@@ -96,7 +96,7 @@ class precip::php {
   
   # Add Composer's vendor directory to the vagrant user's $PATH
   file { '/home/vagrant/.pam_environment':
-    mode    => 644,
+    mode    => '0644',
     content => 'PATH DEFAULT=${PATH}:/home/vagrant/.composer/vendor/bin',
     require => Class['composer'],
   }


### PR DESCRIPTION
(Resolves #17)

Does the thing.

"Warning: Setting templatedir is deprecated" Errors Begone!
