### PR TITLE
Completely Refactor PHP installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
   # Vagrant Box Address
   # This is a happy base box from PuppetLabs
   config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
-  config.vm.box_version = "1.0.0"
+  config.vm.box_version = "1.0.3"
 
   # Basic network config.
   config.vm.network :private_network, ip: "10.0.0.11"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ drupal_sites = {}
 drupal_basepath = "sites"
 internal_hosts = []
 external_hosts = {}
+packaging_mode = false
 
 # Determine if this is our first boot or not. 
 # If there's a better way to figure this out we now have a single place to change.
@@ -166,6 +167,7 @@ Vagrant.configure(2) do |config|
       "drupal_hosts" => internal_hosts.to_json,
       "external_hosts" => external_hosts.to_json,
       "first_boot" => first_boot,
+      "packaging_mode" => packaging_mode,
     }
   end
 end

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -11,8 +11,7 @@ mod 'ftaeger-mailhog', "1.1.0"
 
 #mod 'thias-php', "1.2.0"
 #mod 'willdurand-composer'
-mod 'voxpupuli-php',
-  :github_tarball => 'voxpupuli/puppet-php'
+mod 'mayflower-php'
 
 mod 'jlondon-wkhtmltox'
 

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -9,9 +9,10 @@ mod 'puppetlabs-mysql', "3.2.0"
 mod 'puppetlabs-vcsrepo'
 mod 'ftaeger-mailhog', "1.1.0"
 
-mod 'thias-php', "1.2.0"
-
-mod 'willdurand-composer'
+#mod 'thias-php', "1.2.0"
+#mod 'willdurand-composer'
+mod 'voxpupuli-php',
+  :github_tarball => 'voxpupuli/puppet-php'
 
 mod 'jlondon-wkhtmltox'
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -24,14 +24,16 @@ FORGE
     saz-memcached (2.8.1)
       puppetlabs-firewall (>= 0.1.0)
       puppetlabs-stdlib (>= 3.2.0)
-    thias-php (1.2.0)
-    willdurand-composer (1.2.1)
-      puppetlabs-stdlib (>= 3.2.1)
 
 PATH
   remote: /vagrant/puppet/precip
   specs:
     clwdev-precip (0.0.1)
+
+GITHUBTARBALL
+  remote: voxpupuli/puppet-php
+  specs:
+    voxpupuli-php (4.0.0-beta1)
 
 DEPENDENCIES
   clwdev-precip (>= 0)
@@ -42,6 +44,5 @@ DEPENDENCIES
   puppetlabs-mysql (= 3.2.0)
   puppetlabs-vcsrepo (>= 0)
   saz-memcached (>= 0)
-  thias-php (= 1.2.0)
-  willdurand-composer (>= 0)
+  voxpupuli-php (>= 0)
 

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,12 +1,22 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
+    darin-zypprepo (1.0.2)
+    example42-puppi (2.2.1)
+    example42-yum (2.1.27)
+      example42-puppi (>= 2.0.0)
     ftaeger-mailhog (1.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 4.10.0)
     jlondon-wkhtmltox (1.0.11)
       maestrodev-wget (>= 1.5.0)
       puppetlabs-stdlib (>= 0)
     maestrodev-wget (1.7.3)
+    mayflower-php (4.0.0-beta1)
+      darin-zypprepo (~> 1.0)
+      example42-yum (~> 2.0)
+      puppetlabs-apt (< 3.0.0, >= 1.8.0)
+      puppetlabs-inifile (~> 1.0)
+      puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
     nanliu-staging (1.0.3)
     puppetlabs-apache (1.10.0)
       puppetlabs-concat (< 3.0.0, >= 1.1.1)
@@ -16,6 +26,7 @@ FORGE
     puppetlabs-concat (2.1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-firewall (1.8.1)
+    puppetlabs-inifile (1.6.0)
     puppetlabs-mysql (3.2.0)
       nanliu-staging (~> 1.0)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
@@ -30,19 +41,14 @@ PATH
   specs:
     clwdev-precip (0.0.1)
 
-GITHUBTARBALL
-  remote: voxpupuli/puppet-php
-  specs:
-    voxpupuli-php (4.0.0-beta1)
-
 DEPENDENCIES
   clwdev-precip (>= 0)
   ftaeger-mailhog (= 1.1.0)
   jlondon-wkhtmltox (>= 0)
+  mayflower-php (>= 0)
   puppetlabs-apache (>= 0)
   puppetlabs-apt (>= 0)
   puppetlabs-mysql (= 3.2.0)
   puppetlabs-vcsrepo (>= 0)
   saz-memcached (>= 0)
-  voxpupuli-php (>= 0)
 

--- a/puppet/precip/manifests/database.pp
+++ b/puppet/precip/manifests/database.pp
@@ -14,17 +14,6 @@ class precip::database {
     require => File['/etc/mysql'],
   }
   
-  # New Keys for Percona Server
-  apt::key { 'percona':
-    id     => '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A',
-    server => 'keyserver.ubuntu.com',
-  }
-  
-  apt::key { 'percona-packaging':
-    id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
-    server => 'keyserver.ubuntu.com',
-  }
-  
   # Define the Percona apt repo
   apt::source { 'Percona':
     location => 'http://repo.percona.com/apt',

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -2,7 +2,11 @@ class precip::httpd {
   # Need to specifically ask for Prefork, otherwise Ubuntu will go grab Worker
   # (Worker is weird)
   class { 'apache': mpm_module => "prefork" }
-  class { 'apache::mod::php': }
+  class { 'apache::mod::php': 
+    package_name => "libapache2-mod-php5.6",
+    path => "/usr/lib/apache2/modules/libphp5.6.so",
+    require => Class['php']
+  }
   class { 'apache::mod::ssl': }
   class { 'apache::mod::rewrite': }
 

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -37,16 +37,16 @@ class precip {
   }
 
   # Grab some gems.
-  # @TODO: Convert to a bundle? Define a bundle path in config.rb and bundle install each of those?
-  package {[
-    "compass",
-    "breakpoint",
-    "sass",
-    "susy",
-    ]:
-    ensure => 'installed',
-    provider => 'gem',
-  }
+  # Commented out for now, until we figure out task runners
+  # package {[
+  #   "compass",
+  #   "breakpoint",
+  #   "sass",
+  #   "susy",
+  #   ]:
+  #   ensure => 'installed',
+  #   provider => 'gem',
+  # }
 
   # Make our log directory
   file {"/vagrant/log": ensure => "directory", }

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -89,6 +89,7 @@ class precip {
   class { 'mailhog': }
 
   # Kick off the rest of our manifests
+  include 'precip::keys'
   include 'precip::php'
   include 'precip::httpd'
   include 'precip::database'

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -13,6 +13,7 @@ class precip {
     "imagemagick",
     "vim",
     "g++",
+    "software-properties-common",
     ]:
     ensure => present,
   }

--- a/puppet/precip/manifests/init.pp
+++ b/puppet/precip/manifests/init.pp
@@ -90,10 +90,12 @@ class precip {
 
   # Kick off the rest of our manifests
   include 'precip::keys'
-  include 'precip::php'
-  include 'precip::httpd'
-  include 'precip::database'
-  include 'precip::pimpmylog'
+  if !str2bool("$packaging_mode") {
+    include 'precip::php'
+    include 'precip::httpd'
+    include 'precip::database'
+    include 'precip::pimpmylog'
+  }
   
   # More elegant workaround for vbguest's issue #95
   # See: https://github.com/dotless-de/vagrant-vbguest/issues/95#issuecomment-163777475

--- a/puppet/precip/manifests/keys.pp
+++ b/puppet/precip/manifests/keys.pp
@@ -1,0 +1,24 @@
+class precip::keys {
+  # Turns out in *some* situations, like a heavily locked-down network, you 
+  # can't do key exchange the normal way using apt::key. It fails *very* 
+  # messily, and then you can't install things via a apt, and that's bad! 
+  # Breaking our required external keys into a separate include will make it 
+  # easier to conditionally require them during the Box Packing Process.
+
+  # Percona's keys
+  apt::key { 'percona':
+    id     => '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A',
+    server => 'keyserver.ubuntu.com',
+  }
+  
+  apt::key { 'percona-packaging':
+    id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+    server => 'keyserver.ubuntu.com',
+  }
+  
+  # Ondrej's PPA key
+  apt::key { 'ppa:ondrej':
+    id     => '14AA40EC0831756756D7F66C4F4EA0AAE5267A6C',
+    server => 'keyserver.ubuntu.com',
+  }
+}

--- a/shell/package.sh
+++ b/shell/package.sh
@@ -20,6 +20,7 @@ vagrant destroy --force
 
 echo "Prepping config.rb and sites folder"
 cp config.rb-dist config.rb
+echo "packaging_mode = true" | tee -a config.rb
 mkdir -p "$BASEDIR/../sites" >/dev/null 2>&1
 
 echo "Installing prerequisites"


### PR DESCRIPTION
PHP installation had to be completely refactored for two reasons:

1) On the 1.0.3 base-box the wrong version of PHP was being installed, and Ondrej’s repo was being ignored. Turns out this was actually only previously working by accident.

2) To support Ondrej’s new "php" repo instead of the no-longer-supported "php5-5.6" repo, we needed a module we could specify that with.

Turns out switching to voxpupuli-php fixes both of those issues.

This is going to need some testing, as it may still be a bit bumpy. Tough to tell how much of that is the fault of this PR or the fault of the Dyn-pocalypse from earlier today, though.
