### PR TITLE
Refactor local settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#![precip](precip-logo-thin.png)
+![precip](precip-logo-thin.png)
 
 # Precip: Local Development for Cloud-y Drupal
 **Precip** is a [Vagrant](http://www.vagrantup.com)-based all-inclusive local development environment for building Drupal Sites you'll eventually be pushing up to one of several wonderful Drupal Cloud Hosting Services. It's initially being built against Acquia Cloud, but may eventually support other similar services.

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -19,12 +19,6 @@ class precip::httpd {
     notify => Service['apache2'],
   }
 
-  # We'll need this when we make our vhosts
-  file {"/var/www/site-php":
-    ensure => "directory",
-    mode => '0755',
-  }
-
   # We'll also need this if there are any commands defined
   file { "/vagrant/bin": 
     ensure => "directory"
@@ -129,27 +123,13 @@ define drupal_vhosts($host, $aliases = [], $path, $drupal = "7", $multisite_dir 
       ensure =>'directory',
       mode => '0775',
     }
-
-    # Ensure the tree we're going to hide settings in exists
-    file {"/var/www/site-php/${name}":
-      ensure => "directory",
-      mode => '0775',
-      require => File["/var/www/site-php"],    
-    }
-
-    # Magic Acquia-style Database Settings.
-    file {"/var/www/site-php/${name}/${name}-settings.inc":
-      content => template("precip/drupal_${drupal}_database_socket.erb"),
-      mode => '0775',
-      subscribe => File["/var/www/site-php/${name}"],
-    }
     
-    # A template "local-settings.inc", in case you don't have one already
+    # "local-settings.inc", a way of setting extra stuff for local development
     file {"/srv/www/${path}/sites/${multisite_dir}/local-settings.inc":
-      content => template("precip/drupal_${drupal}_database.erb"),
+      content => template("precip/drupal_${drupal}_local_settings_inc.erb"),
       replace => false,
       mode => '0775',
-      subscribe => File["/var/www/site-php/${name}"],
+      subscribe => File["/srv/www/${path}/sites/${multisite_dir}"],
     }
     
     # An Acquia-style settings.php, if you need one.

--- a/puppet/precip/templates/drupal_6_local_settings_inc.erb
+++ b/puppet/precip/templates/drupal_6_local_settings_inc.erb
@@ -1,0 +1,15 @@
+<?php
+/**
+ * D6-style Settings Include
+ * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *     DO NOT COMMIT THIS FILE UNDER ANY CIRCUMSTANCES       *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ */
+
+$db_url = 'mysql://<%= @name %>:<%= @name %>@<%= @fqdn %>/<%= @name %>';
+$db_prefix = '';
+
+if(!PHP_SAPI=='cli'){
+  $db_url = 'mysql://<%= @name %>:<%= @name %>@127.0.0.1/<%= @name %>';
+}

--- a/puppet/precip/templates/drupal_6_settings_php.erb
+++ b/puppet/precip/templates/drupal_6_settings_php.erb
@@ -35,12 +35,17 @@ $conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
  * Database connection for Acquia Cloud
  * Including all other settings controlled by Acquia
  */
- if ($site && file_exists('/var/www/site-php/' . $site . '/' . $site . '-settings.inc')) {
-   require '/var/www/site-php/' . $site . '/' . $site . '-settings.inc';
- }
- else if (realpath(dirname(__FILE__) . '/local-settings.inc')){
-  // This workaround ensures local Drush works
-  // "Vagrant as a Remote" Drush just isn't ready for primetime :(
+if ($site && file_exists('/var/www/site-php/' . $site . '/' . $site . '-settings.inc')) {
+  require '/var/www/site-php/' . $site . '/' . $site . '-settings.inc';
+}
+
+/**
+ * Database connections for local development
+ * . . . and also some other stuff, if you need it.
+ *
+ * * * * * * * * DO NOT COMMIT THIS FILE * * * * * * * * 
+ */
+if (realpath(dirname(__FILE__) . '/local-settings.inc')){
   require realpath(dirname(__FILE__) . '/local-settings.inc');
 }
 

--- a/puppet/precip/templates/drupal_7_local_settings_inc.erb
+++ b/puppet/precip/templates/drupal_7_local_settings_inc.erb
@@ -1,0 +1,26 @@
+<?php
+/**
+ * D7-style Database Include
+ * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *     DO NOT COMMIT THIS FILE UNDER ANY CIRCUMSTANCES       *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ */
+
+$databases['default']['default'] = array(
+ 'driver' => 'mysql',
+ 'database' => '<%= @name %>',
+ 'username' => '<%= @name %>',
+ 'password' => '<%= @name %>',
+ 'host' => '<%= @fqdn %>',
+ 'prefix' => '',
+);
+
+if(!PHP_SAPI=='cli'){
+  $databases['default']['default']['host'] = '127.0.0.1';
+  $databases['default']['default']['unix_socket'] = '/var/run/mysqld/mysqld.sock';
+}
+
+$conf['memcache_servers'] = array('precip.vm:11211' => 'default');
+
+$drupal_hash_salt = "precip.vm";

--- a/puppet/precip/templates/drupal_7_settings_php.erb
+++ b/puppet/precip/templates/drupal_7_settings_php.erb
@@ -31,8 +31,14 @@ drupal_fast_404();
 if ($site && file_exists('/var/www/site-php/' . $site . '/' . $site . '-settings.inc')) {
   require '/var/www/site-php/' . $site . '/' . $site . '-settings.inc';
 }
-else if (realpath(dirname(__FILE__) . '/local-settings.inc')){
-  // Otherwise, Include local-settings.inc, if it's here.
+
+/**
+ * Database connections for local development
+ * . . . and also some other stuff, if you need it.
+ *
+ * * * * * * * * DO NOT COMMIT THIS FILE * * * * * * * * 
+ */
+if (realpath(dirname(__FILE__) . '/local-settings.inc')){
   require realpath(dirname(__FILE__) . '/local-settings.inc');
 }
 
@@ -51,16 +57,15 @@ else if (realpath(dirname(__FILE__) . '/local-settings.inc')){
  * Setting Drupal Private Files Path as per:
  * https://docs.acquia.com/articles/setting-private-file-directory-acquia-cloud
  */
- if (isset($_ENV['AH_SITE_ENVIRONMENT']) && $_ENV['AH_SITE_ENVIRONMENT'] != "local") {
-   $files_private_conf_path = conf_path();
-   $conf['file_private_path'] = '/mnt/files/' . $_ENV['AH_SITE_GROUP'] . '.' . $_ENV['AH_SITE_ENVIRONMENT'] . '/' . $files_private_conf_path . '/files-private';
- }
- else {
-   $conf['file_private_path'] = 'sites/<%= @multisite_dir %>/files';
- }
+if (isset($_ENV['AH_SITE_ENVIRONMENT']) && $_ENV['AH_SITE_ENVIRONMENT'] != "local") {
+  $files_private_conf_path = conf_path();
+  $conf['file_private_path'] = '/mnt/files/' . $_ENV['AH_SITE_GROUP'] . '.' . $_ENV['AH_SITE_ENVIRONMENT'] . '/' . $files_private_conf_path . '/files-private';
+}
+else {
+  $conf['file_private_path'] = 'sites/<%= @multisite_dir %>/files';
+}
 
 /**
  *  Domain 301 Settings (Don't)
  */
-
 $conf['domain_301_redirect_enabled'] = 0;


### PR DESCRIPTION
- Refactor everything about how `local-settings.inc` works
- Now there's no duplication between your db include and `local-settings.inc`, it's all in one place.
- You may need to delete your existing `local-settings.inc` and change how it's being included, assuming you have a committed `settings.php`.