### PR TITLE
Implement PHP 7.1 as an option for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A full LAMP stack, and a few nice extras.
 - Ubuntu Server 16.04.2 LTS
 - Apache Server 2.4
 - MariaDB 10.1
-- PHP 5.6 *or* 7.0
+- PHP 5.6, 7.0 _and_ 7.1
   - With Memcache, OPCache, and Xdebug all pre-configured
 - MailHog, the _absolute_ simplest way to locally test mail delivery
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,7 @@ drupal_sites.each do |name, site|
   end
 end
 internal_hosts.push("70.precip.vm")
+internal_hosts.push("71.precip.vm")
 internal_hosts = internal_hosts.flatten
 
 # The actual Vagrant Configuration

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -26,6 +26,15 @@ class precip::httpd {
     file_type  => 'application/x-httpd-php-7.0'
   }
 
+  apache::fastcgi::server { 'php71':
+    host       => '/run/php/php7.1-fpm.sock',
+    timeout    => 300,
+    flush      => false,
+    faux_path  => '/var/www/php71.fcgi',
+    fcgi_alias => '/php71.fcgi',
+    file_type  => 'application/x-httpd-php-7.1'
+  }
+
   # We'll also need this if there are any commands defined
   file { '/vagrant/bin':
     ensure => 'directory'
@@ -54,6 +63,18 @@ class precip::httpd {
     }],
     access_log     => false,
     custom_fragment => 'AddType application/x-httpd-php-7.0 .php'
+  }
+
+  apache::vhost { '71.precip.vm':
+    docroot        => '/vagrant/util',
+    manage_docroot => false,
+    port           => '80',
+    directories    => [{
+        path           => '/vagrant/util',
+        allow_override => ['All',],
+    }],
+    access_log     => false,
+    custom_fragment => 'AddType application/x-httpd-php-7.1 .php'
   }
 
   $parsed_siteinfo = parsejson($drupal_siteinfo)


### PR DESCRIPTION
Copy/Paste all the 7.0 stuff and bump to 7.1.

Turns out it was exactly that easy.

To use, set your `php_version` to "7.1" instead of "7.0" in your `config.rb`.