### PR TITLE
[rsync] WIP: Support rsync

### DIFF
--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -7,6 +7,7 @@ required_plugins = {
   'vagrant-useradd'            => '0.0.1',
   'vagrant-bindfs'             => '1.0.8',
   'vagrant-persistent-storage' => '0.0.33',
+  'vagrant-gatling-rsync'      => '~>0.9.0',
 }
 
 needs_restart = false

--- a/config.rb-dist
+++ b/config.rb-dist
@@ -101,6 +101,10 @@
 #
 # vm_name = "not-precip"
 
+# Use rsync instead of NFS for site files. This can improve performance on larger sites.
+#
+# rsync = true
+
 # We offer a partially pre-built version of the Precip Base Box, which ships with 
 # all keys and base packages pre-installed, so all that's left is installing PHP, 
 # Apache, MySQL, and Configuring everything. This can help on restrictive networks


### PR DESCRIPTION
We previously needed to do this as the performance was very slow. On updating to the newest version of precip this no longer appears to be the case so this may not be necessary any more.

### Current known issues (Why this is a WIP)
1. Cannot vagrant up with rsync enabled. If you vagrant up with rsync disabled you can then reload with it enabled and it will work.
2. files folder is not created for the Drupal sites (this can be created in the vm and must be owned by www-data).