### PR TITLE
Implement PHP 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 ## What's Included?
 A full LAMP stack, and a few nice extras.
-- Ubuntu Server 16.04.2 LTS
+- Ubuntu Server 16.04.3 LTS
 - Apache Server 2.4
 - MariaDB 10.1
-- PHP 5.6, 7.0 _and_ 7.1
+- PHP 5.6, 7.0, 7.1 and 7.2
   - With Memcache, OPCache, and Xdebug all pre-configured
 - MailHog, the _absolute_ simplest way to locally test mail delivery
 
@@ -23,8 +23,10 @@ A full LAMP stack, and a few nice extras.
 
 ## Pre-flight Checklist
 - Get [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-- Also [Vagrant](http://www.vagrantup.com/downloads.html)
-- Then go download these super helpful Vagrant Plugins (If you forget to, Vagrant will install them for you. It *might* error on your first `vagrant up`, but should still install things fine.)
+  - Note: You _probably_ want to stick on 5.1.x for now
+  - Precip _technically_ supports Virtualbox 5.2.x with Vagrant 2.0.1+, but it's _very_ early days for the 5.2.x branch right now, proceed with caution
+- Get [Vagrant](http://www.vagrantup.com/downloads.html)
+- Download these super helpful Vagrant Plugins (If you forget to, Vagrant will install them for you. It *might* error on your first `vagrant up`, but should still install things fine.)
   - `$ vagrant plugin install vagrant-vbguest`
   - `$ vagrant plugin install vagrant-hostsupdater`
   - `$ vagrant plugin install vagrant-useradd`
@@ -42,18 +44,17 @@ A full LAMP stack, and a few nice extras.
   - **Warning:** This will probably take geologic age the first time, since Vagrant first has to download the ~200Mb base box. It's a one-time thing, though.
 - Once Vagrant downloads the base box it will hand off to Puppet for provisioning
 - Once Puppet is finished provisioning your environment will be ready to use!
-- If you're on OS X or Linux, you _may_ want to run `$ vagrant reload` after your first boot. It'll boost MySQL performance a bit.
 
 #### Special note about versions and dependencies
  - As a general rule, getting latest Vagrant, Virtualbox and plugins is advised
- - BUT if you have issues, as sometimes bleeding edge releases can have unreported / unresolved bugs, roll back to prior versions by uninstalling and re-installing that earlier version (and search issue queues). The Macosx package includes an uninstaller script.
- - Current known stable releases as of March 7, 2017: 
+ - BUT if you have issues, as sometimes bleeding edge releases can have unreported / unresolved bugs, roll back to prior versions by uninstalling and re-installing that earlier version (and search issue queues). The MacOS package includes an uninstaller script.
+ - Current known stable releases as of November 30th, 2017:
     - vagrant 1.9.7
-    - vagrant-bindfs (1.0.8)
+    - vagrant-bindfs (1.0.9)
     - vagrant-hostsupdater (1.0.2)
-    - vagrant-persistent-storage (0.0.33)
+    - vagrant-persistent-storage (0.0.37)
     - vagrant-useradd (0.0.1)
-    - vagrant-vbguest (0.14.2)
+    - vagrant-vbguest (0.15.0)
  
 ## Updating Vagrant
 - If you do a `$ git pull` and see that the `Vagrantfile` has been updated, you may want to make sure things are up to date by running `$ vagrant reload --provision`.
@@ -108,7 +109,8 @@ PHP is already set up to use it, but if for some reason you're making something 
 - Customize local-settings.inc (optional)
 
 # Known Issues
-- [ ] During Provisioning, Puppet complains about "Warning: Setting templatedir is deprecated." [It's a Vagrant Bug](https://github.com/mitchellh/vagrant/issues/3740).
+- [x] ~~During Provisioning, Puppet complains about "Warning: Setting templatedir is deprecated." [It's a Vagrant Bug](https://github.com/mitchellh/vagrant/issues/3740).~~
+- [ ] In migrating between VirtualBox 5.1.x and 5.2.x you may get a big angry red "Vagrant was unable to mount VirtualBox shared folders." fatal error on boot. Dumb Workaround: `vagrant reload --provision`.
 
 # @TODO
 - [x] ~~Puppet Library Caching~~
@@ -121,7 +123,10 @@ PHP is already set up to use it, but if for some reason you're making something 
 - [x] ~~Actual Testing on Windows~~
 - [x] ~~Figure out NFS support on Windows~~ (gave up)
 - [x] ~~[Pimp My Log](http://pimpmylog.com) support~~
-- [ ] Some sort of generalized environment pulldown script
+- [X] ~~Some sort of generalized environment pulldown script~~ (belongs elsewhere)
+- [ ] A reasonable memcached dashboard
+- [ ] Reduce repetition in `php.pp`
+- [ ] Implement some sort of reasonable way to skip installation of some stuff (like, if you _really_ only need _one_ version of PHP)
 - [ ] Other Cool Stuff?????
 
 # Legal

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ drupal_sites.each do |name, site|
     internal_hosts.push(site['aliases'])
   end
 end
+internal_hosts.push("56.precip.vm")
 internal_hosts.push("70.precip.vm")
 internal_hosts.push("71.precip.vm")
 internal_hosts.push("72.precip.vm")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ drupal_sites.each do |name, site|
 end
 internal_hosts.push("70.precip.vm")
 internal_hosts.push("71.precip.vm")
+internal_hosts.push("72.precip.vm")
 internal_hosts = internal_hosts.flatten
 
 # The actual Vagrant Configuration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ vm_name = "precip"
 use_packaged_precip = false
 mysql_storage_size = 32768
 vm_memory = 2048
+nfs_killswitch = false
 
 # Determine if this is our first boot or not. 
 # If there's a better way to figure this out we now have a single place to change.
@@ -82,8 +83,9 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_agent = forward_ssh_agent
 
   # Synced Folders
-  if Vagrant::Util::Platform.windows?
+  if Vagrant::Util::Platform.windows? || nfs_killswitch
     # Windows gets vboxsf, because it can't do nfs + bindfs
+    # ...or if nfs_killswitch is enabled, for stupid MacOS workarounds
     config.vm.synced_folder drupal_basepath, "/srv/www", owner: "www-data", group: "www-data"
   else
     # Everybody else gets nfs + bindfs, for better small-file read perf

--- a/config.rb-dist
+++ b/config.rb-dist
@@ -120,6 +120,18 @@
 #
 # use_packaged_precip = true
 
+# By default on operating systems that support it (eg: not Windows), we mount the
+# drupal_sites directory as nfs then rig it to a bindfs mount, as this allows the OS
+# to treat it as a Big Boy drive, while also dramatically increasing performance.
+#
+# Turns out MacOS 10.13 High Sierra broke NFS pretty horribly. Whoops.
+# https://github.com/hashicorp/vagrant/issues/8788
+#
+# It's slated to be fixed in 10.13.2, but in the meantime a simple way to just kill
+# NFS support is helpful. So add 'nfs_killswitch = true' to config.rb and you're done.
+#
+# nfs_killswitch = true
+
 drupal_sites = {
 #   "example" => {
 #     "host" => "example.vm",

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -59,7 +59,7 @@ class precip::httpd {
         allow_override => ['All',],
     }],
     access_log     => false,
-    custom_fragment => 'AddType application/x-httpd-php-5.6 .php'
+    custom_fragment => 'AddType application/x-httpd-php-7.1 .php'
   }
 
   apache::vhost { '70.precip.vm':
@@ -115,7 +115,7 @@ class precip::httpd {
   }
 }
 
-define drupal_vhosts($host, $aliases = [], $path, $drupal = '7', $multisite_dir = 'default', $setenv = [], $git_url = '', $git_dir = '', $commands = {}, $ssl_cert = '/vagrant/ssl/precip_vm_host.pem', $ssl_ca = '/vagrant/ssl/precip_ca_bundle.crt.pem', $ssl_key = '/vagrant/ssl/precip_vm_host-key.pem', $php_version = '5.6') {
+define drupal_vhosts($host, $aliases = [], $path, $drupal = '7', $multisite_dir = 'default', $setenv = [], $git_url = '', $git_dir = '', $commands = {}, $ssl_cert = '/vagrant/ssl/precip_vm_host.pem', $ssl_ca = '/vagrant/ssl/precip_ca_bundle.crt.pem', $ssl_key = '/vagrant/ssl/precip_vm_host-key.pem', $php_version = '7.1') {
   apache::vhost { $host:
     docroot        => "/srv/www/${path}",
     manage_docroot => false,

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -62,6 +62,18 @@ class precip::httpd {
     custom_fragment => 'AddType application/x-httpd-php-7.1 .php'
   }
 
+  apache::vhost { '56.precip.vm':
+    docroot        => '/vagrant/util',
+    manage_docroot => false,
+    port           => '80',
+    directories    => [{
+        path           => '/vagrant/util',
+        allow_override => ['All',],
+    }],
+    access_log     => false,
+    custom_fragment => 'AddType application/x-httpd-php-7.0 .php'
+  }
+
   apache::vhost { '70.precip.vm':
     docroot        => '/vagrant/util',
     manage_docroot => false,

--- a/puppet/precip/manifests/httpd.pp
+++ b/puppet/precip/manifests/httpd.pp
@@ -35,6 +35,15 @@ class precip::httpd {
     file_type  => 'application/x-httpd-php-7.1'
   }
 
+  apache::fastcgi::server { 'php72':
+    host       => '/run/php/php7.2-fpm.sock',
+    timeout    => 300,
+    flush      => false,
+    faux_path  => '/var/www/php72.fcgi',
+    fcgi_alias => '/php72.fcgi',
+    file_type  => 'application/x-httpd-php-7.2'
+  }
+
   # We'll also need this if there are any commands defined
   file { '/vagrant/bin':
     ensure => 'directory'
@@ -75,6 +84,18 @@ class precip::httpd {
     }],
     access_log     => false,
     custom_fragment => 'AddType application/x-httpd-php-7.1 .php'
+  }
+
+  apache::vhost { '72.precip.vm':
+    docroot        => '/vagrant/util',
+    manage_docroot => false,
+    port           => '80',
+    directories    => [{
+        path           => '/vagrant/util',
+        allow_override => ['All',],
+    }],
+    access_log     => false,
+    custom_fragment => 'AddType application/x-httpd-php-7.2 .php'
   }
 
   $parsed_siteinfo = parsejson($drupal_siteinfo)


### PR DESCRIPTION
[PHP 7.2 went final today](http://php.net/releases/7_2_0.php), so Precip should support it. Good news is that's _super_ easy now.

Couple notes:
- [PHP 7.2 no longer has mcrypt](https://wiki.php.net/rfc/mcrypt-viking-funeral). Like, there literally isn't a package for it anymore. Need mcrypt? That's your problem to figure out. Maybe stick to PHP 7.1 until it gets fully deprecated.
- Previously if you didn't set a `php_version` in your `config.rb` new hosts would default to PHP 5.6. Now it they default to PHP 7.1.
- Similarly, the default `precip.vm` host has been swapped over to PHP 7.1
- Due to the above change, I've added 56.precip.vm, in case you need to quickly see your 5.6 phpinfo

While I was in here making changes I also implemented a dead simple workaround for the NFS-on-High-Sierra bug. From `config.rb-dist`:

```
# By default on operating systems that support it (eg: not Windows), we mount the
# drupal_sites directory as nfs then rig it to a bindfs mount, as this allows the OS
# to treat it as a Big Boy drive, while also dramatically increasing performance.
#
# Turns out MacOS 10.13 High Sierra broke NFS pretty horribly. Whoops.
# https://github.com/hashicorp/vagrant/issues/8788
#
# It's slated to be fixed in 10.13.2, but in the meantime a simple way to just kill
# NFS support is helpful. So add 'nfs_killswitch = true' to config.rb and you're done.
#
# nfs_killswitch = true
```

So no need to comment stuff out in your `Vagrantfile` anymore.